### PR TITLE
[ENH] buffer name, buffer append, and comments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ vimmock = __import__('vimmock')
 readme_file = os.path.join(os.path.dirname(__file__), 'README.rst')
 try:
     long_description = open(readme_file).read()
-except IOError, err:
+except IOError as err:
     sys.stderr.write("[ERROR] Cannot find file specified as "
         "``long_description`` (%s)\n" % readme_file)
     sys.exit(1)

--- a/vimmock/mocked.py
+++ b/vimmock/mocked.py
@@ -1,13 +1,78 @@
+"""
+
+Place this script in your the vimrc to inspect attributes of the real vim
+python module. This can be used to make this module more accurately reflect the
+real vim object.
+
+python << endpython
+
+def attrinfo(basename, base, attrname):
+    attr = getattr(base, attrname)
+    print('\n------')
+    print('%s.%s: %r' % (basename, attrname, attr))
+    print('type(%s.%s): %r' % (basename, attrname, type(attr)))
+    print('dir(%s.%s): %r' % (basename, attrname, dir(attr)))
+
+print('\n\n VIM BASE')
+print('vim = %r' % (vim,))
+print('type(vim) = %r' % (type(vim),))
+print('dir(vim) = %r' % (dir(vim),))
+
+print('\n\n VIM CURRENT')
+attrinfo('vim', vim, 'current')
+attrinfo('vim.current', vim.current, 'tabpage')
+attrinfo('vim.current', vim.current, 'line')
+attrinfo('vim.current', vim.current, 'window')
+attrinfo('vim.current', vim.current, 'range')
+
+attrinfo('vim.current', vim.current, 'buffer')
+
+attrinfo('vim.current.buffer', vim.current.buffer, 'number')
+attrinfo('vim.current.buffer', vim.current.buffer, 'name')
+attrinfo('vim.current.buffer', vim.current.buffer, 'options')
+attrinfo('vim.current.buffer', vim.current.buffer, 'range')
+attrinfo('vim.current.buffer', vim.current.buffer, 'valid')
+attrinfo('vim.current.buffer', vim.current.buffer, 'vars')
+attrinfo('vim.current.buffer', vim.current.buffer, 'mark')
+
+endpython
+"""
+
+
+class VimErrorMock(Exception):
+    pass
+
+
 class LineMock(object):
     pass
 
 
-classname = lambda obj: obj.__class__.__name__
+def classname(obj):
+    return obj.__class__.__name__
 
 
 class BufferMock(object):
+    """
+    Attributes of the REAL vim.buffer object
+        ['__dir__', '__members__', 'append', 'mark', 'name', 'number', 'options',
+        'range', 'valid', 'vars']
+    """
     def __init__(self, text=None):
+        self._lines = None
+        self.name = ''
+
+        self.number = 1
+        self.range = RangeMock
+        self.valid = False
+        # self.options = OptionsMock
+        # self.vars = DictionaryMock()
+        self.mark = None
+
         self.setup_text(text)
+
+    @property
+    def _text(self):
+        return '\n'.join(self._lines)
 
     def __getitem__(self, key):
         if isinstance(key, slice):
@@ -24,32 +89,191 @@ class BufferMock(object):
         self._lines[key] = value
 
     def setup_text(self, text=None):
-        self._text = text or ''
-        self._lines = self._text.splitlines()
+        text = text or ''
+        self._lines = text.splitlines()
+        self.valid = True
+        self.name = ''
+
+    def open_file(self, filepath):
+        with open(filepath, 'r') as file_:
+            self._lines = file_.read().splitlines()
+        self.valid = True
+        self.name = filepath
+
+    def append(self, other):
+        """ the vim buffer append is actually an extend call """
+        self._lines.extend(other)
 
 
 class WindowMock(object):
+    """"
+    RealObjectInfo:
+        vim.current.window: <window 0>
+        type(vim.current.window): <type 'vim.window'>
+        dir(vim.current.window): ['__dir__', '__members__', 'buffer', 'col',
+            'cursor', 'height', 'number', 'options', 'row', 'tabpage', 'valid',
+            'vars']
+    """
     def __init__(self, cursor=None):
         self.cursor = cursor or (0, 0)
 
 
 class RangeMock(object):
+    """
+    RealObjectInfo:
+        vim.current.range: <range  (1:1)>
+        type(vim.current.range): <type 'vim.range'>
+        dir(vim.current.range): ['__dir__', '__members__', 'append', 'end', 'start']
+    """
+    pass
+
+
+class TabPageMock(object):
+    """
+    RealObjectInfo:
+        vim.current.tabpage: <tabpage 0>
+        type(vim.current.tabpage): <type 'vim.tabpage'>
+        dir(vim.current.tabpage): ['__dir__', '__members__', 'number', 'valid',
+                                   'vars', 'window', 'windows']
+    """
     pass
 
 
 class CurrentMock(object):
+    """
+    RealObjectInfo:
+        vim.current: <vim.currentdata object at 0x8718a0>
+        type(vim.current): <type 'vim.currentdata'>
+        dir(vim.current): ['__dir__', '__members__', 'buffer', 'line', 'range', 'tabpage', 'window']
+    """
     def __init__(self, text=None):
         self.line = LineMock()
         self.buffer = BufferMock(text)
         self.window = WindowMock()
         self.range = RangeMock()
+        self.tabpage = TabPageMock()
 
 
 class VimMock(object):
+    """
+
+    The real vim module is defined in the c source code (if_python.c,
+    if_python3.c, if_py_both.h, etc...) in the vim package.  Therefore it is difficult to
+    replicate its behavior exactly.
+
+    vim = <module 'vim' (built-in)>
+    type(vim) = <type 'module'>
+
+    The Attributes of the REAL vim module are:
+    {
+         # Vim Types
+        'Buffer': vim.buffer,
+        'Dictionary': vim.dictionary,
+        'Function': vim.function,
+        'List': vim.list,
+        'Options': vim.options,
+        'Range': vim.range,
+        'TabPage': vim.tabpage,
+        'Window': vim.window,
+        '_Loader': vim.Loader,
+
+        # Members of numeric_constant
+        'VAR_DEF_SCOPE': 2,
+        'VAR_FIXED': 2,
+        'VAR_LOCKED': 1,
+        'VAR_SCOPE': 1,
+        'VIM_SPECIAL_PATH': '_vim_path_',
+
+        # Members of object_constant
+        'buffers': <vim.bufferlist object at 0x8718d0>,
+        'windows': <vim.windowlist object at 0x8718b0>,
+        'current': <vim.currentdata object at 0x8718a0>,
+        'tabpages': <vim.tabpagelist object at 0x871890>,
+
+         # The vim module definitions
+        'command': <built-in function command>,
+        'eval': <built-in function eval>,
+        'bindeval': <built-in function bindeval>,
+        'strwidth': <built-in function strwidth>,
+        'chdir': <built-in function chdir>,
+        'fchdir': <built-in function fchdir>,
+        'foreach_rtp': <built-in function foreach_rtp>,
+        'find_module': <built-in function find_module>,
+        'path_hook': <built-in function path_hook>,
+        '_get_paths': <built-in function _get_paths>,
+
+        # Python versions of redefined functions
+        '_chdir': <built-in function chdir>,
+        '_fchdir': <built-in function fchdir>,
+        '_find_module': <built-in function find_module>,
+        '_getcwd': <built-in function getcwd>,
+        '_load_module': <built-in function load_module>,
+
+        # Checked objects
+        'options': <vim.options object at 0x7fae81970c30>,
+        'vars': <vim.dictionary object at 0x7fae8196dc90>,
+        'vvars': <vim.dictionary object at 0x7fae8196dcc0>,
+
+        # Error definition
+        'error': vim.error,
+
+        '__doc__': None,
+        '__name__': 'vim',
+        '__package__': None,
+
+        # The module also defines these attributes, but they are just imprted from
+        # other places
+        'os': <module 'os' from '/usr/lib/python2.7/os.pyc'>,
+        }
+    """
+    VAR_DEF_SCOPE = 2
+    VAR_FIXED = 2
+    VAR_LOCKED = 1
+    VAR_SCOPE =  1
+    VIM_SPECIAL_PATH = '_vim_path_'
+
+    Buffer = BufferMock
+    Range = RangeMock
+    TabPage = TabPageMock
+    Window = WindowMock
+    # Dictionary = vim.dictionary
+    # Function = vim.function
+    # List = vim.list
+    # Options = vim.options
+    # _Loader = vim.Loader
+
+    error = VimErrorMock
 
     def __init__(self):
         self.current = CurrentMock()
 
+        self.buffers = [self.current.buffer]  # vim.bufferlist
+        self.windows = [self.current.window]  # vim.bufferlist
+        self.tabpages = [self.current.tabpage]  # vim.tabpagelist
+
     def setup_text(self, text):
+        """
+        special mock-only function to put text into the buffer
+        """
         self.current.buffer.setup_text(text)
 
+    def open_file(self, filepath, cursor=None):
+        """
+        special mock-only function to put text into the buffer
+        """
+        # Create a buffer and set it as the current buffer
+        new_buffer = BufferMock()
+        new_buffer.open_file(filepath)
+        self.buffers.append(new_buffer)
+        self.current.buffer = new_buffer
+        self.current.window.cursor = cursor or (0, 0)
+
+    def eval(self, command):
+        hard_coded_commands = {
+            'jedi#_vim_exceptions("&encoding", 1)': {'result': 'utf-8'},
+            '&encoding': 'utf-8',
+        }
+        if command in hard_coded_commands:
+            return hard_coded_commands[command]
+        raise NotImplementedError('eval not generally implemented')
+        # maybe :e will call open_file?

--- a/vimmock/tests.py
+++ b/vimmock/tests.py
@@ -27,6 +27,16 @@ class TestVimMock(unittest.TestCase):
         self.vim.setup_text('foobar')
         self.vim.current.buffer.setup_text.assert_called_once_with('foobar')
 
+    def test_open_file(self):
+        filepath = vimmock.mocked.__file__.replace('*.pyc', '*.py')
+        self.vim.open_file(filepath)
+        assert self.vim.current.buffer.name == filepath
+
+    def test_eval(self):
+        assert self.vim.eval('&encoding') == 'utf-8'
+        with self.assertRaises(NotImplementedError):
+            self.vim.eval(':e ~')
+
 
 class TestBufferMock(unittest.TestCase):
 
@@ -61,6 +71,11 @@ class TestBufferMock(unittest.TestCase):
     def test_setup_text(self):
         self.buffer.setup_text('\n'.join(('foo', 'bar')))
 
+    def test_append(self):
+        self.buffer.append(['spam'])
+        assert self.buffer._text == 'foo\nbar\nbaz\nspam'
+
+
 class TestCurrentMock(unittest.TestCase):
 
     def setUp(self):
@@ -84,4 +99,3 @@ class TestPatch(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
The purpose of this PR is to extend the current functionality of this module to more accurately reflect the real vim module. 

The main changes I've made are to add the `open_file` function to the `VimMock` object. This allows testing beyond just using the `setup_text` method because it sets the name in addition to the buffer data. 
I've also added the `append` method (which actually works more like extend) to the buffer object. 

I also added a `eval` function, but its quite stupid right now and only works for two hard coded commands that I happen to be using in my script.

I've also added a few placeholder variables based on how the real vim module is setup. Furthermore I added comments showing how to inspect the real vim module so additional functionality can be added as needed.  

I made one change to setup.py because using IOError, err apparently caused an exception. I update the syntax. 

I've added tests for all the new functionality to ensure coverage remains at 100%. 